### PR TITLE
store token position + fix tokenizer

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
   ],
   "type": "module",
   "types": "dist/htmldiff.d.ts",
-  "dependencies": {},
+  "dependencies": {
+    "xregexp": "^5.0.2"
+  },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "~4.16.1",
     "@typescript-eslint/parser": "~4.16.1",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "lint": "eslint --config='.eslintrc.cjs' './src/*.ts' --fix",
     "test": "npm run make && mocha -R min",
     "make": "tsc -p tsconfig.json",
+    "prepare": "npm run make",
     "diff": "git diff -- :/ ':(exclude,top)dist/*'"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "scripts": {
     "lint": "eslint --config='.eslintrc.cjs' './src/*.ts' --fix",
     "test": "npm run make && mocha -R min",
-    "make": "tsc -p tsconfig.json"
+    "make": "tsc -p tsconfig.json",
+    "diff": "git diff -- :/ ':(exclude,top)dist/*'"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "private": true,
   "license": "MIT",
-  "main": "dist/htmldiff.ts",
+  "main": "dist/htmldiff.js",
   "files": [
     "dist/htmldiff.d.ts",
     "dist/htmldiff.js",

--- a/src/htmldiff.ts
+++ b/src/htmldiff.ts
@@ -25,6 +25,11 @@
  *   htmldiff('<p>this is some text</p>', '<p>this is some more text</p>', 'diff-class')
  *   == '<p>this is some <ins class="diff-class">more </ins>text</p>'
  */
+
+import XRegExp from 'xregexp';
+
+const unicodeLetterExpr = XRegExp('\\p{L}|\\d');
+
 function isEndOfTag(char: string): boolean {
   return char === '>';
 }
@@ -189,8 +194,9 @@ export function htmlToTokens(html: string): Token[] {
   let currentAtomicTag = '';
   const words = [];
 
-  for (let charIdx = 0; charIdx < html.length; charIdx++) {
-    const char = html[charIdx] as string;
+  const unicodeChars = Array.from(html);
+  for (let charIdx = 0; charIdx < unicodeChars.length; charIdx++) {
+    const char = unicodeChars[charIdx] as string;
     switch (mode){
       case 'tag': {
         const atomicTag = isStartOfAtomicTag(currentWord);
@@ -251,7 +257,7 @@ export function htmlToTokens(html: string): Token[] {
           currentWord = char;
           currentWordPos = charIdx;
           mode = 'whitespace';
-        } else if (/[\w\d#@]/.test(char)){
+        } else if (unicodeLetterExpr.test(char)) {
           currentWord += char;
         } else if (char == '&'){
           if (currentWord){

--- a/src/htmldiff.ts
+++ b/src/htmldiff.ts
@@ -302,8 +302,8 @@ export function htmlToTokens(html: string): Token[] {
             words.push(createToken(currentWord, currentWordPos));
           }
           currentWord = '';
-          charIdx--; // seek back
           currentWordPos = charIdx;
+          charIdx--; // seek back
           mode = 'char';
         }
         break;

--- a/src/htmldiff.ts
+++ b/src/htmldiff.ts
@@ -261,7 +261,9 @@ export function htmlToTokens(html: string): Token[] {
           currentWordPos = charIdx;
           mode = 'entity';
         } else {
-          words.push(createToken(currentWord, currentWordPos));
+          if (currentWord){
+            words.push(createToken(currentWord, currentWordPos));
+          }
           words.push(createToken(char, charIdx));
           currentWord = '';
           currentWordPos = charIdx + 1;

--- a/src/htmldiff.ts
+++ b/src/htmldiff.ts
@@ -689,8 +689,10 @@ export function findMatchingBlocks(segment: Segment): Match[] {
   return nodeToArray(matches);
 }
 
+type OperationAction = 'none' | 'equal' | 'insert' | 'delete' | 'replace';
+
 type Operation = {
-  action: 'equal' | 'insert' | 'delete' | 'replace';
+  action: OperationAction;
   startInBefore: number;
   endInBefore?: number;
   startInAfter: number;
@@ -725,7 +727,7 @@ export function calculateOperations(beforeTokens: Token[], afterTokens: Token[])
   matches.push(makeMatch(beforeTokens.length, afterTokens.length, 0, segment));
 
   matches.forEach(match => {
-    let actionUpToMatchPositions: 'equal' | 'insert' | 'delete' | 'replace' | 'none'  = 'none';
+    let actionUpToMatchPositions: OperationAction  = 'none';
     if (positionInBefore === match.startInBefore){
       if (positionInAfter !== match.startInAfter){
         actionUpToMatchPositions = 'insert';
@@ -951,9 +953,10 @@ function wrap(tag: string, content: string[], opIndex: number, dataPrefix: strin
  * @return {string} The rendering of that operation.
  */
 const renderHandler: {
-  [K in 'equal' | 'insert' | 'delete' | 'replace'] : (op: Operation, beforeTokens: Token[], afterTokens: Token[], opIndex: number, dataPrefix: string, className: string) => string
+  [action in OperationAction] : (op: Operation, beforeTokens: Token[], afterTokens: Token[], opIndex: number, dataPrefix: string, className: string) => string
 } = {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  none: () => '',
   'equal': function(op: Operation, beforeTokens: Token[], afterTokens: Token[], opIndex: number, dataPrefix: string, className: string){
     const tokens = op.endInAfter ?
       afterTokens.slice(op.startInAfter, op.endInAfter + 1) :

--- a/src/htmldiff.ts
+++ b/src/htmldiff.ts
@@ -295,7 +295,8 @@ export function htmlToTokens(html: string): Token[] {
           if (currentWord){
             words.push(createToken(currentWord, currentWordPos));
           }
-          currentWord = char;
+          currentWord = '';
+          charIdx--; // seek back
           currentWordPos = charIdx;
           mode = 'char';
         }

--- a/src/htmldiff.ts
+++ b/src/htmldiff.ts
@@ -931,7 +931,7 @@ function wrap(tag: string, content: string[], opIndex: number, dataPrefix: strin
 }
 
 /**
- * OPS.equal/insert/delete/replace are functions that render an operation into
+ * renderHandler.equal/insert/delete/replace are functions that render an operation into
  * HTML content.
  *
  * @param {Object} op The operation that applies to a prticular list of tokens. Has the
@@ -950,7 +950,7 @@ function wrap(tag: string, content: string[], opIndex: number, dataPrefix: strin
  *
  * @return {string} The rendering of that operation.
  */
-const OPS: {
+const renderHandler: {
   [K in 'equal' | 'insert' | 'delete' | 'replace'] : (op: Operation, beforeTokens: Token[], afterTokens: Token[], opIndex: number, dataPrefix: string, className: string) => string
 } = {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -981,8 +981,8 @@ const OPS: {
     return wrap('del', val, opIndex, dataPrefix, className);
   },
   'replace': function(op: Operation, beforeTokens: Token[], afterTokens: Token[], opIndex: number, dataPrefix: string, className: string){
-    return OPS.delete.apply(null, [op, beforeTokens, afterTokens, opIndex, dataPrefix, className])
-      + OPS.insert.apply(null, [op, beforeTokens, afterTokens, opIndex, dataPrefix, className]);
+    return renderHandler.delete.apply(null, [op, beforeTokens, afterTokens, opIndex, dataPrefix, className])
+      + renderHandler.insert.apply(null, [op, beforeTokens, afterTokens, opIndex, dataPrefix, className]);
   }
 };
 
@@ -1007,7 +1007,7 @@ const OPS: {
  */
 export function renderOperations(beforeTokens: Token[], afterTokens: Token[], operations: Operation[], dataPrefix: string, className: string){
   return operations.reduce(function(rendering: string, op: Operation, index: number){
-    return rendering + OPS[op.action](
+    return rendering + renderHandler[op.action](
       op, beforeTokens, afterTokens, index, dataPrefix, className);
   }, '');
 }

--- a/src/htmldiff.ts
+++ b/src/htmldiff.ts
@@ -253,17 +253,30 @@ export function htmlToTokens(html: string): Token[] {
           mode = 'whitespace';
         } else if (/[\w\d#@]/.test(char)){
           currentWord += char;
-        } else if (/&/.test(char)){
+        } else if (char == '&'){
           if (currentWord){
             words.push(createToken(currentWord, currentWordPos));
           }
           currentWord = char;
           currentWordPos = charIdx;
+          mode = 'entity';
         } else {
+          words.push(createToken(currentWord, currentWordPos));
+          words.push(createToken(char, charIdx));
+          currentWord = '';
+          currentWordPos = charIdx + 1;
+        }
+        break;
+      case 'entity':
+        if (char == ';') {
           currentWord += char;
           words.push(createToken(currentWord, currentWordPos));
           currentWord = '';
           currentWordPos = charIdx + 1;
+          mode = 'char';
+        }
+        else {
+          currentWord += char;
         }
         break;
       case 'whitespace':

--- a/test/html_to_tokens.spec.js
+++ b/test/html_to_tokens.spec.js
@@ -8,8 +8,11 @@ describe('htmlToTokens', function(){
     cut = htmlToTokens;
 
     tokenize = function(tokens){
+      let tokenIdx = 0;
       return tokens.map(function(token){
-        return createToken(token);
+        const res = createToken(token, tokenIdx);
+        tokenIdx += token.length;
+        return res;
       });
     };
   });


### PR DESCRIPTION
this is useful for a "live diff" editor, where i must reset the cursor position

[WIP demo: live html diff editor with htmldiff.js](https://codesandbox.io/s/htmldiffjs-live-diff-demo-work-in-progress-rneyc?file=/src/index.js)

edit: this use case is deprecated, since every diff-algo will produce "false diffs"
and the only way to get a "real live diff" this is to track the `input` and `selectionchange` events

[WIP demo 2: live html diff editor with inputevent](https://codesandbox.io/s/javascript-live-html-diff-editor-work-in-progress-7045p?file=/src/index.js) (also on [github](https://github.com/milahu/live-diff-html-editor))

other small edits ...

6ea5b33 `word,` should be tokenized to `|word|,|` not to `|word,|`

3fefdab <code>&nbsp; &nbsp; "word</code> should be tokenized to <code>|&nbsp; &nbsp; |"|word|</code> not to <code>|&nbsp; &nbsp; |"word|</code>
`|word|deletion|"|` -> `|word|"|` should produce a delete, no replace

a77f632 `wörd` should be tokenized to `|wörd|` not to `|wö|rd|`
`for (const char of str)` will loop unicode chars, `const char = str[i]` will loop bytes ([src](https://stackoverflow.com/questions/10758913/unicode-string-with-diacritics-split-by-chars))
[xregexp](https://github.com/slevithan/xregexp) is a fast unicode matcher ([src](https://stackoverflow.com/questions/20422194/extract-words-in-string-with-unicode-characters))
