### PR TITLE
html diff support style tags

### DIFF
--- a/test/html_to_tokens.spec.js
+++ b/test/html_to_tokens.spec.js
@@ -33,8 +33,8 @@ describe('htmlToTokens', function(){
       res = htmlToTokens('<p>this is a <strong>test</strong></p>');
     });
 
-    it('should return 11', function(){
-      expect(res.length).to.equal(11);
+    it('should return 9', function(){
+      expect(res.length).to.equal(9);
     });
 
     it('should remove any html comments', function(){


### PR DESCRIPTION
Parses content within style tags (`strong`, `em`) as token wrapped with style tag. Breaks up blocks of styled text into individual tokens consisting of one word within styled tags, so that granular differences can still be recognized.